### PR TITLE
Fix Carbon usage

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -139,7 +139,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ];
         $alternatives = array();
         $i = 0;
-        $tanggal = Carbon::create(Now())->format('Y-m-d');
+        $tanggal = Carbon::now()->format('Y-m-d');
         $permintaan = PermintaanLayanan::with([
             'tipe_permintaan',
             'pasien',


### PR DESCRIPTION
## Summary
- replace deprecated `Carbon::create(Now())` with `Carbon::now()`

## Testing
- `php artisan test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402ebe41808324968f0b0ca294bc77